### PR TITLE
Add Jump To Test (split) for paneful workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode-test/
 *.vsix
 npm-debug.log
+package-lock.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,5 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:extension.jumpToTest"
+        "onCommand:extension.jumpToTest",
+        "onCommand:extension.jumpToTestSplit"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
             {
                 "command": "extension.jumpToTest",
                 "title": "Jump to Test"
+            },
+            {
+                "command": "extension.jumpToTestSplit",
+                "title": "Jump to Test (Split)"
             }
         ],
         "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,10 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 export function activate(context: vscode.ExtensionContext) {
-  let disposable = vscode.commands.registerCommand('extension.jumpToTest', () => {
+  function jumpToTest() {jumpTo(false)}
+  function jumpToTestSplit() {jumpTo(true)}
+
+  function jumpTo(split) {
     const splitFileName: string[] = path.basename(vscode.window.activeTextEditor.document.fileName).split(".");
     const fileName: string = splitFileName.slice(0,-1).join('');
     const extension: string = splitFileName[splitFileName.length-1];
@@ -18,7 +21,13 @@ export function activate(context: vscode.ExtensionContext) {
         return;  
       }  
 
-      vscode.commands.executeCommand('vscode.open', vscode.Uri.file(ps[0].path));
+      if (split) {
+        vscode.window.showTextDocument(vscode.Uri.file(ps[0].path), {
+            viewColumn: vscode.ViewColumn.Beside
+        });
+      } else {
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.file(ps[0].path));
+      }
     });
 
     function determineGlobPattern(globPattern: string, extension: string): string {
@@ -52,5 +61,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  context.subscriptions.push(disposable);
+  let disposableJumpTo = vscode.commands.registerCommand('extension.jumpToTest', jumpToTest)
+  let disposableJumpToSplit = vscode.commands.registerCommand('extension.jumpToTestSplit', jumpToTestSplit)
+  context.subscriptions.push(disposableJumpTo);
+  context.subscriptions.push(disposableJumpToSplit);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (split) {
         vscode.window.showTextDocument(vscode.Uri.file(ps[0].path), {
-            viewColumn: vscode.ViewColumn.Beside
+            viewColumn: vscode.ViewColumn.Two
         });
       } else {
         vscode.commands.executeCommand('vscode.open', vscode.Uri.file(ps[0].path));
@@ -59,10 +59,10 @@ export function activate(context: vscode.ExtensionContext) {
     function addPostfix(globPattern: string): string {
       return globPattern.includes('_') ? '_' : '';
     }
-  });
+  }
 
-  let disposableJumpTo = vscode.commands.registerCommand('extension.jumpToTest', jumpToTest)
-  let disposableJumpToSplit = vscode.commands.registerCommand('extension.jumpToTestSplit', jumpToTestSplit)
+  let disposableJumpTo = vscode.commands.registerCommand('extension.jumpToTest', jumpToTest);
+  let disposableJumpToSplit = vscode.commands.registerCommand('extension.jumpToTestSplit', jumpToTestSplit);
   context.subscriptions.push(disposableJumpTo);
   context.subscriptions.push(disposableJumpToSplit);
 }


### PR DESCRIPTION
Adds a new command to open the test file beside the current one, so you can edit tests and look at your code at the same time.

Pretty sure you were there the last time I wrote javascript so lmk if anything is horribly wrong